### PR TITLE
FIX: radio value falsly submitted as array

### DIFF
--- a/Resources/Private/Partials/Form/Field/Radio.html
+++ b/Resources/Private/Partials/Form/Field/Radio.html
@@ -8,7 +8,7 @@
                 field: {
                     label: '{f:render(partial: \'Form/FieldLabel\', arguments: \'{_all}\') -> headless:format.json.decode()}',
                     marker: field.marker,
-                    name: '{headlesspowermail:form.generateName(property:\'{field.marker}.\')}',
+                    name: '{headlesspowermail:form.generateName(property:\'{field.marker}\')}',
                     css: field.css,
                     fieldWrappingClasses: settings.styles.framework.fieldWrappingClasses,
                     fieldAndLabelWrappingClasses: settings.styles.framework.fieldAndLabelWrappingClasses,


### PR DESCRIPTION
Radio fields currently have their name attribute set to `tx_powermail_pi1[field][myradiofield][]` which is "array mode" and not possible for radio since only one option can be selected.

Typical symptom of this: fields like salutation are printed as `["Mrs"]` instead of just `Mrs`.