### PR TITLE
Add RedirectFinisher that performs redirect with JSON response

### DIFF
--- a/Classes/Finisher/RedirectFinisher.php
+++ b/Classes/Finisher/RedirectFinisher.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+namespace FriendsOfTYPO3\HeadlessPowermail\Finisher;
+
+use In2code\Powermail\Domain\Service\RedirectUriService;
+use In2code\Powermail\Utility\FrontendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class RedirectFinisher extends \In2code\Powermail\Finisher\RedirectFinisher
+{
+    /**
+     * Redirect user after form submit
+     *
+     * @return void
+     */
+    public function redirectToUriFinisher(): void
+    {
+        $redirectService = GeneralUtility::makeInstance(RedirectUriService::class, $this->contentObject);
+        $uri = $redirectService->getRedirectUri();
+        if (!empty($uri) && $this->isRedirectEnabled()) {
+            echo json_encode([
+                'redirectUrl' => $uri,
+                'statusCode' => 303,
+            ]);
+            die;
+        }
+    }
+}

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,3 +1,14 @@
+plugin.tx_powermail {
+    settings {
+        setup {
+            finishers {
+                # Override powermail's RedirectFinisher
+                100.class = FriendsOfTYPO3\HeadlessPowermail\Finisher\RedirectFinisher
+            }
+        }
+    }
+}
+
 tt_content.list =< lib.contentElementWithHeader
 tt_content.list {
     fields {


### PR DESCRIPTION
Instead of actually performing a HTTP redirect this uses a JSON response to do so.

Compare with powermail's RedirectFinisher: https://github.com/einpraegsam/powermail/blob/develop/Classes/Finisher/RedirectFinisher.php#L31

Resolves: #25