### PR TITLE
Support both: single and multiple select fields

### DIFF
--- a/Resources/Private/Partials/Form/Field/Country.html
+++ b/Resources/Private/Partials/Form/Field/Country.html
@@ -1,6 +1,7 @@
 {namespace vh=In2code\Powermail\ViewHelpers}
 <f:spaceless>
-    <headlesspowermail:form.registerField property="{field.marker}"
+    <f:variable name="fieldMarker" value="{field.marker}{f:if(condition:field.multiselect,then:'.')}" />
+    <headlesspowermail:form.registerField property="{fieldMarker}"
                             value="{setting.value}"
                             checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:index.cycle)}"/>
     <f:format.raw>
@@ -8,12 +9,14 @@
                 field: {
                     label: '{f:render(partial: \'Form/FieldLabel\', arguments: \'{_all}\') -> headless:format.json.decode()}',
                     marker: field.marker,
-                    name: '{headlesspowermail:form.generateName(property:\'{field.marker}\')}',
+                    name: '{headlesspowermail:form.generateName(property:fieldMarker)}',
                     css: field.css,
                     fieldWrappingClasses: settings.styles.framework.fieldWrappingClasses,
                     fieldAndLabelWrappingClasses: settings.styles.framework.fieldAndLabelWrappingClasses,
                     validationClass: '{vh:validation.errorClass(field:field, class:\'powermail_field_error\')}',
                     additionalAttributes: '{vh:validation.validationDataAttribute(field:field)}',
+                    multiple: field.multiselectForField,
+                    multiselect: field.multiselect,
                     type: 'select',
                     client: settings.validation.client,
                     options: '{f:render(section:\'select\',arguments:\'{_all}\') -> headless:format.json.decode()}'

--- a/Resources/Private/Partials/Form/Field/Select.html
+++ b/Resources/Private/Partials/Form/Field/Select.html
@@ -1,6 +1,7 @@
 {namespace vh=In2code\Powermail\ViewHelpers}
 <f:spaceless>
-    <headlesspowermail:form.registerField property="{field.marker}"
+    <f:variable name="fieldMarker" value="{field.marker}{f:if(condition:field.multiselect,then:'.')}" />
+    <headlesspowermail:form.registerField property="{fieldMarker}"
                             value="{setting.value}"
                             checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:index.cycle)}"/>
     <f:format.raw>
@@ -8,7 +9,7 @@
                 field: {
                     label: '{f:render(partial: \'Form/FieldLabel\', arguments: \'{_all}\') -> headless:format.json.decode()}',
                     marker: field.marker,
-                    name: '{headlesspowermail:form.generateName(property:\'{field.marker}\')}',
+                    name: '{headlesspowermail:form.generateName(property:fieldMarker)}',
                     css: field.css,
                     fieldWrappingClasses: settings.styles.framework.fieldWrappingClasses,
                     fieldAndLabelWrappingClasses: settings.styles.framework.fieldAndLabelWrappingClasses,


### PR DESCRIPTION

![image](https://github.com/TYPO3-Headless/headless_powermail/assets/1405149/440f2bfe-0aaa-4c9c-a4d3-1d957e14f743)


Currently select fields with "multiple" mode will not be handled correctly due to
* wrong name attribute and 
* wrong variable name in __trustedProperties

Needs to be reviewed/merged after #30 