### PR TITLE
Remove dead property 'linkedMandatory'

### DIFF
--- a/Resources/Private/Partials/Form/FieldLabel.html
+++ b/Resources/Private/Partials/Form/FieldLabel.html
@@ -4,7 +4,6 @@
         <f:format.json value="{
             css: field.css,
             mandatory: field.mandatory,
-            linkedMandatory: field.linkedMandatory,
             labelClasses: settings.styles.framework.labelClasses,
             title: field.title,
             description: field.description,


### PR DESCRIPTION
This property doesn't exist and shouldn't be rendered at all.